### PR TITLE
入力フォームの高さを自動調節するカスタムフックを作成

### DIFF
--- a/src/InputForm.tsx
+++ b/src/InputForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useRef, useEffect } from 'react'
 import styled from 'styled-components'
 import * as color from './color'
 import { Button, ConfirmButton } from './Button'
@@ -21,9 +21,12 @@ export const InputForm = ({
     if (disabled) return onConfirm?.()
   }
 
+  const ref = useAutoFitToContentHeight(value)
+
   return (
     <Container className={className}>
       <Input
+        ref={ref} // refをpropsとして渡し、HTML要素の実体を保持する
         autoFocus
         placeholder="Enter a note"
         value={value}
@@ -40,6 +43,32 @@ export const InputForm = ({
       </ButtonRow>
     </Container>
   )
+}
+
+/**
+ * テキストエリアの高さを内容に合わせて自動調整する
+ * 
+ * @param content テキストエリアの内容
+ */
+const useAutoFitToContentHeight = (content: string | undefined) => {
+  // useRefはミュータブルな値を保持するオブジェクトを返す
+  const ref = useRef<HTMLTextAreaElement>(null)
+
+  // useEffectは副作用を伴う処理を登録するために用いる
+  useEffect(
+    () => {
+      const el = ref.current
+      if (!el) return
+
+      const { borderTopWidth, borderBottomWidth } = getComputedStyle(el)
+      el.style.height = 'auto' // 一度 auto にしないと高さが縮まなくなる
+      el.style.height = `calc(${borderTopWidth} + ${el.scrollHeight}px + ${borderBottomWidth})`
+    },
+    // 内容が変わるたびに高さを再計算
+    [content],
+  )
+
+  return ref
 }
 
 const Container = styled.div``


### PR DESCRIPTION
- [x] テキストエリアの高さ(行数)が初期状態を超えた場合、追加行数に応じて入力フォームの高さが増えること(スクロールバーが表示されないこと)